### PR TITLE
Add configuration option for feature to disallow contributors as reviewers

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -38,13 +38,13 @@ const (
 
 // Configuration is used to configure the approval process for PRs in a given repository.
 type Configuration struct {
-	// DisallowContributorApproval will enforce that an reviewer can not approve a pull request that they have contributed
-	//towards. That is, an approvers review is only considered if they have _not_ pushed a commit to the branch being merged.
+	// IgnoreContributorApproval will enforce that an reviewer can not approve a pull request that they have contributed
+	// towards. That is, an reviewer's approval is only considered if they have _not_ pushed a commit to the branch being merged.
 	// This does not include UI merges from the repositories main branch.
- 	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details
+ 	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
 	// Defaults to false.
-	DisallowContributorApproval bool
-	PullRequestApprovalRules []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
+	IgnoreContributorApproval bool
+	PullRequestApprovalRules  []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
 }
 
 // PullRequestApprovalRule is used to associate a set of rules with a set of target branches.

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -38,6 +38,11 @@ const (
 
 // Configuration is used to configure the approval process for PRs in a given repository.
 type Configuration struct {
+	// DisableContributorReview will enforce that an reviewer can not approve a pull request that they have contributed
+	//towards. That is, an approvers review is only considered if they have _not_ pushed a commit to the branch being merged.
+	// This does not include UI merges from the repositories main branch.
+	// Defaults to false.
+	DisableContributorReview bool
 	PullRequestApprovalRules []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
 }
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -38,12 +38,12 @@ const (
 
 // Configuration is used to configure the approval process for PRs in a given repository.
 type Configuration struct {
-	// DisableContributorReview will enforce that an reviewer can not approve a pull request that they have contributed
+	// DisallowContributorApproval will enforce that an reviewer can not approve a pull request that they have contributed
 	//towards. That is, an approvers review is only considered if they have _not_ pushed a commit to the branch being merged.
 	// This does not include UI merges from the repositories main branch.
  	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details
 	// Defaults to false.
-	DisableContributorReview bool
+	DisallowContributorApproval bool
 	PullRequestApprovalRules []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
 }
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -38,8 +38,8 @@ const (
 
 // Configuration is used to configure the approval process for PRs in a given repository.
 type Configuration struct {
-	// IgnoreContributorApproval will enforce that an reviewer can not approve a pull request that they have contributed
-	// towards. That is, an reviewer's approval is only considered if they have _not_ pushed a commit to the branch being merged.
+	// IgnoreContributorApproval will enforce that a reviewer can not approve a pull request that they have contributed
+	// towards. That is, a reviewer's approval is only considered if they have _not_ pushed a commit to the branch being merged.
 	// This does not include UI merges from the repositories main branch.
  	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
 	// Defaults to false.

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -41,6 +41,7 @@ type Configuration struct {
 	// DisableContributorReview will enforce that an reviewer can not approve a pull request that they have contributed
 	//towards. That is, an approvers review is only considered if they have _not_ pushed a commit to the branch being merged.
 	// This does not include UI merges from the repositories main branch.
+ 	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details
 	// Defaults to false.
 	DisableContributorReview bool
 	PullRequestApprovalRules []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`


### PR DESCRIPTION
This flag will be used by the `form3tech-oss/github-team-approver` to control the mentioned feature.

See https://github.com/form3tech-oss/github-team-approver/pull/29