### PR TITLE
Adds yaml tag to Configuration.IgnoreContributorApproval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+if: "(type IN (push, cron) AND branch = master) OR (type = pull_request) OR (tag IS present)"
+language: go
+go:
+  - '1.17.2'
+script:
+  - GO111MODULE=off go test ./... -v

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -43,7 +43,7 @@ type Configuration struct {
 	// This does not include UI merges from the repositories main branch.
  	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
 	// Defaults to false.
-	IgnoreContributorApproval bool
+	IgnoreContributorApproval bool `yaml:"ignore_contributor_approval"`
 	PullRequestApprovalRules  []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
 }
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1,7 +1,7 @@
 package configuration_test
 
 import (
-    "strings"
+    "os"
     "testing"
 
     "github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
@@ -11,20 +11,13 @@ import (
 
 func Test_ReadConfiguration(t *testing.T) {
     tt := []struct {
-        name     string
-        payload  string
-        expected configuration.Configuration
+        name        string
+        payloadPath string
+        expected    configuration.Configuration
     }{
         {
-            name: "basic",
-            payload: `
-ignore_contributor_approval: false
-pull_request_approval_rules:
-    - rules:
-       - regex: "regex"
-         approving_team_handles:
-         - team-a
-         - team-b`,
+            name:        "basic",
+            payloadPath: "./testdata/configuration_basic.yaml",
             expected: configuration.Configuration{
                 IgnoreContributorApproval: false,
                 PullRequestApprovalRules: []configuration.PullRequestApprovalRule{
@@ -46,8 +39,8 @@ pull_request_approval_rules:
 
     for _, tc := range tt {
         t.Run(tc.name, func(t *testing.T) {
-            strings.NewReader(tc.payload)
-            cfg, err := configuration.ReadConfiguration(strings.NewReader(tc.payload))
+            cfgFile, err := os.Open(tc.payloadPath)
+            cfg, err := configuration.ReadConfiguration(cfgFile)
             require.NoError(t, err)
             require.NotNil(t, cfg)
             assert.Equal(t, *cfg, tc.expected)

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1,0 +1,56 @@
+package configuration_test
+
+import (
+    "strings"
+    "testing"
+
+    "github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
+    "github.com/magiconair/properties/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func Test_ReadConfiguration(t *testing.T) {
+    tt := []struct {
+        name     string
+        payload  string
+        expected configuration.Configuration
+    }{
+        {
+            name: "basic",
+            payload: `
+ignore_contributor_approval: false
+pull_request_approval_rules:
+    - rules:
+       - regex: "regex"
+         approving_team_handles:
+         - team-a
+         - team-b`,
+            expected: configuration.Configuration{
+                IgnoreContributorApproval: false,
+                PullRequestApprovalRules: []configuration.PullRequestApprovalRule{
+                    {
+                        Rules: []configuration.Rule{
+                            {
+                                Regex: "regex",
+                                ApprovingTeamHandles: []string{
+                                    "team-a",
+                                    "team-b",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    for _, tc := range tt {
+        t.Run(tc.name, func(t *testing.T) {
+            strings.NewReader(tc.payload)
+            cfg, err := configuration.ReadConfiguration(strings.NewReader(tc.payload))
+            require.NoError(t, err)
+            require.NotNil(t, cfg)
+            assert.Equal(t, *cfg, tc.expected)
+        })
+    }
+}

--- a/pkg/configuration/testdata/configuration_basic.yaml
+++ b/pkg/configuration/testdata/configuration_basic.yaml
@@ -1,0 +1,7 @@
+ignore_contributor_approval: false
+pull_request_approval_rules:
+  - rules:
+      - regex: "regex"
+        approving_team_handles:
+          - team-a
+          - team-b


### PR DESCRIPTION
Adds tests for unmarshal behaviour. The motivation is cover the new field and to add the foundation for other test cases to catch issues like forgetting to set struct tags.