### PR TITLE
feat: required approvals per team config

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -41,10 +41,13 @@ type Configuration struct {
 	// IgnoreContributorApproval will enforce that a reviewer can not approve a pull request that they have contributed
 	// towards. That is, a reviewer's approval is only considered if they have _not_ pushed a commit to the branch being merged.
 	// This does not include UI merges from the repositories main branch.
- 	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
+	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
 	// Defaults to false.
 	IgnoreContributorApproval bool `yaml:"ignore_contributor_approval"`
-	PullRequestApprovalRules  []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
+	// RequiredApprovalsPerTeam enforces the minimum approvals required per configured team.
+	// Defaults to 1.
+	RequiredApprovalsPerTeam int                       `yaml:"required_approvals_per_team"`
+	PullRequestApprovalRules []PullRequestApprovalRule `yaml:"pull_request_approval_rules"`
 }
 
 // PullRequestApprovalRule is used to associate a set of rules with a set of target branches.
@@ -86,7 +89,7 @@ type Alert struct {
 
 // ReadConfiguration attempts to read a Configuration object from the provided Reader.
 func ReadConfiguration(r io.Reader) (*Configuration, error) {
-	v := &Configuration{}
+	v := &Configuration{RequiredApprovalsPerTeam: 1}
 	d := yaml.NewDecoder(r)
 	if err := d.Decode(v); err != nil {
 		return nil, fmt.Errorf("error decoding configuration: %v", err)

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1,49 +1,71 @@
 package configuration_test
 
 import (
-    "os"
-    "testing"
+	"os"
+	"testing"
 
-    "github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
-    "github.com/magiconair/properties/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ReadConfiguration(t *testing.T) {
-    tt := []struct {
-        name        string
-        payloadPath string
-        expected    configuration.Configuration
-    }{
-        {
-            name:        "basic",
-            payloadPath: "./testdata/configuration_basic.yaml",
-            expected: configuration.Configuration{
-                IgnoreContributorApproval: false,
-                PullRequestApprovalRules: []configuration.PullRequestApprovalRule{
-                    {
-                        Rules: []configuration.Rule{
-                            {
-                                Regex: "regex",
-                                ApprovingTeamHandles: []string{
-                                    "team-a",
-                                    "team-b",
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    }
+	tt := []struct {
+		name        string
+		payloadPath string
+		expected    configuration.Configuration
+	}{
+		{
+			name:        "basic",
+			payloadPath: "./testdata/configuration_basic.yaml",
+			expected: configuration.Configuration{
+				RequiredApprovalsPerTeam:  1,
+				IgnoreContributorApproval: false,
+				PullRequestApprovalRules: []configuration.PullRequestApprovalRule{
+					{
+						Rules: []configuration.Rule{
+							{
+								Regex: "regex",
+								ApprovingTeamHandles: []string{
+									"team-a",
+									"team-b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "required approvals set",
+			payloadPath: "./testdata/configuration_required_approvals.yaml",
+			expected: configuration.Configuration{
+				RequiredApprovalsPerTeam:  2,
+				IgnoreContributorApproval: false,
+				PullRequestApprovalRules: []configuration.PullRequestApprovalRule{
+					{
+						Rules: []configuration.Rule{
+							{
+								Regex: "regex",
+								ApprovingTeamHandles: []string{
+									"team-a",
+									"team-b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
-    for _, tc := range tt {
-        t.Run(tc.name, func(t *testing.T) {
-            cfgFile, err := os.Open(tc.payloadPath)
-            cfg, err := configuration.ReadConfiguration(cfgFile)
-            require.NoError(t, err)
-            require.NotNil(t, cfg)
-            assert.Equal(t, *cfg, tc.expected)
-        })
-    }
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgFile, err := os.Open(tc.payloadPath)
+			cfg, err := configuration.ReadConfiguration(cfgFile)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			assert.Equal(t, *cfg, tc.expected)
+		})
+	}
 }

--- a/pkg/configuration/testdata/configuration_required_approvals.yaml
+++ b/pkg/configuration/testdata/configuration_required_approvals.yaml
@@ -1,0 +1,8 @@
+required_approvals_per_team: 2
+ignore_contributor_approval: false
+pull_request_approval_rules:
+  - rules:
+      - regex: "regex"
+        approving_team_handles:
+          - team-a
+          - team-b


### PR DESCRIPTION
Adding a new config property to be able to set a higher number of approvals for PRs.