### PR TITLE
feat: Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/form3tech-oss/github-team-approver-commons
+module github.com/form3tech-oss/github-team-approver-commons/v2
 
 go 1.18
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/form3tech-oss/github-team-approver-commons/pkg/configuration"
+	"github.com/form3tech-oss/github-team-approver-commons/v2/pkg/configuration"
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
# Context

Release v2.0.0 was made but `go.mod` was not properly updated.

This fix will allow `go get` to automatically pick up the upgrade.