### PR TITLE
feat: add omitempty to ignore_contributor_approval.

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -74,7 +74,7 @@ type Rule struct {
 	// This does not include UI merges from the repositories main branch.
 	// See https://github.com/form3tech-oss/github-team-approver/pull/27 for more details.
 	// Defaults to false.
-	IgnoreContributorApproval bool `yaml:"ignore_contributor_approval"`
+	IgnoreContributorApproval bool `yaml:"ignore_contributor_approval,omitempty"`
 }
 
 type Alert struct {


### PR DESCRIPTION
Adding `omitempty` tag to `ignore_contributor_approval` field.